### PR TITLE
Small compatibility change

### DIFF
--- a/lib/rmodbus/ext.rb
+++ b/lib/rmodbus/ext.rb
@@ -14,7 +14,7 @@
 
 class String
 
-  unless RUBY_VERSION =~ /^1\.9/
+  if RUBY_VERSION < "1.9"
     def getbyte(index)
       self[index].to_i
     end


### PR DESCRIPTION
In ruby 2.0.0 condition for when to override getbyte method triggers unnecessarily. Getbyte method doesn't work properly making decoding device's response throw an exception (rtu.rb, line 28, "Illegal function: 0"). This change basically takes into account ruby versions greater than '1.9'.
