### PR TITLE
Client-side thread safety and increased relience

### DIFF
--- a/lib/rmodbus.rb
+++ b/lib/rmodbus.rb
@@ -37,3 +37,6 @@ require 'rmodbus/rtu_via_tcp_client'
 require 'rmodbus/rtu_via_tcp_server'
 require 'rmodbus/proxy'
 require 'rmodbus/version'
+
+require 'logger'
+$log ||=Logger.new(STDERR)

--- a/lib/rmodbus/debug.rb
+++ b/lib/rmodbus/debug.rb
@@ -20,7 +20,7 @@ module ModBus
 
 
     private
-    # Put log message on standart output
+    # Put log message on standard output
     # @param [String] msg message for log
     def log(msg)
       $stdout.puts msg if @debug

--- a/lib/rmodbus/errors.rb
+++ b/lib/rmodbus/errors.rb
@@ -40,6 +40,9 @@ module ModBus
 
     class MemoryParityError < ModBusException
     end
+    
+    class ProtocolError < ModBusException
+    end
 
     class ModBusTimeout < ModBusException
     end

--- a/lib/rmodbus/rtu_slave.rb
+++ b/lib/rmodbus/rtu_slave.rb
@@ -25,6 +25,17 @@ module ModBus
   # @see Slave
   class RTUSlave < Slave
     include RTU
+    
+    def renew_connection
+      port=@io.port
+      baud=@io.baud
+      @query_lock.synchronize do
+        @io.close
+        @io=open_serial_port(port,baud)
+        clear_buffer
+      end
+    end
+
 
     private
     # overide method for RTU implamentaion

--- a/lib/rmodbus/rtu_via_tcp_slave.rb
+++ b/lib/rmodbus/rtu_via_tcp_slave.rb
@@ -27,13 +27,13 @@ module ModBus
 		include RTU
 
     private
-    # overide method for RTU implamentaion
+    # over-ride method for RTU implementation
     # @see Slave#query
     def send_pdu(pdu)
       send_rtu_pdu(pdu)
     end
 
-    # overide method for RTU implamentaion
+    # over-ride method for RTU implementation
     # @see Slave#query
     def read_pdu
       read_rtu_pdu

--- a/lib/rmodbus/server.rb
+++ b/lib/rmodbus/server.rb
@@ -137,6 +137,23 @@ module ModBus
       end
       params
     end
+    
+    #put the select into a separate method to allow rspec to mock it 
+     #rspec doesn't like IO.select
+     def read_ready? (timeout)
+       IO.select([@io],nil,nil, timeout)
+     end
+    
+     #put the select into a separate method to allow rspec to mock it 
+     #rspec doesn't like IO.select
+     def write_ready? (timeout)
+       IO.select(nil, [@io],nil, timeout)
+     end
+    
+     #stub method to clear the buffer
+     #overwritten by RTU
+     def clear_buffer
+     end   
 
   end
 end

--- a/lib/rmodbus/tcp.rb
+++ b/lib/rmodbus/tcp.rb
@@ -44,5 +44,11 @@ module ModBus
 
       io
     end
+
+    #stub - not really required for ModbusTCP as we are using transaction numbers
+    def clear_buffer
+       #nothing to do here
+    end
+
   end
 end

--- a/lib/rmodbus/tcp_client.rb
+++ b/lib/rmodbus/tcp_client.rb
@@ -1,6 +1,7 @@
 # RModBus - free implementation of ModBus protocol on Ruby.
 #
 # Copyright (C) 2008-2011  Timin Aleksey
+# Copyright (C) 2011  Steve Gooberman-Hill for multithread safety
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,7 +33,7 @@ module ModBus
     end
 
     def get_slave(uid, io)
-      TCPSlave.new(uid, io)
+      TCPSlave.new(uid, io, @query_lock)
     end
   end
 end

--- a/lib/rmodbus/tcp_slave.rb
+++ b/lib/rmodbus/tcp_slave.rb
@@ -1,6 +1,7 @@
 # RModBus - free implementation of ModBus protocol on Ruby.
 #
 # Copyright (C) 2011  Timin Aleksey
+# Copyright (C) 2011  Steve Gooberman-Hill for multithread safety
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,6 +12,8 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
+
+
 module ModBus
   # TCP slave implementation
   # @example
@@ -24,45 +27,99 @@ module ModBus
   # @see Client#with_slave
   # @see Slave
   class TCPSlave < Slave
+    include TCP
     attr_reader :transaction
+    
+    READ_TIMEOUT=0.1
+    THREAD_SLEEP=0.01
+         
 
     # @see Slave::initialize
-    def initialize(uid, io)
+    def initialize(uid, io, lock)
       @transaction = 0
-      super(uid, io)
+      super(uid, io, lock)
     end
 
     private
-    # overide method for RTU over TCP implamentaion
+    # overide method for RTU over TCP implementaion
     # @see Slave#query
     def send_pdu(pdu)
       @transaction = 0 if @transaction.next > 65535
       @transaction += 1
       msg = @transaction.to_word + "\0\0" + (pdu.size + 1).to_word + @uid.chr + pdu
-      @io.write msg
+      length=0
+      
+      begin
+        @io.flush
+        raise ModBus::Errors::ModBusTimeout, 'Device not ready' unless write_ready?(READ_TIMEOUT)      
+        length=@io.syswrite(msg)
+                  
+      rescue SystemCallError => er
+        log "TX: error #{er.to_s}"
+      end
+      raise ModBus::Errors::ProtocolError, "Incomplete Message sent #{length} of #{msg.bytesize}" unless length==msg.bytesize
+      
 
-      log "Tx (#{msg.size} bytes): " + logging_bytes(msg)
+      log "Tx (#{msg.bytesize} bytes): " + logging_bytes(msg)
     end
 
     # overide method for RTU over TCP implamentaion
     # @see Slave#query
     def read_pdu
-      loop do 
-        header = @io.read(7)
-        if header
-          trn = header[0,2].unpack('n')[0]
-          len = header[4,2].unpack('n')[0]
-          msg = @io.read(len-1)
-
-          log "Rx (#{(header + msg).size} bytes): " + logging_bytes(header + msg)
-          
-          if trn == @transaction
-            return msg
-          else
-            log "Transaction number mismatch. A packet is ignored."        
-          end
+      #ensure sockt is nonblocking
+      msg=''
+       
+      begin
+        @io.fcntl(Fcntl::F_SETFL, @io.fcntl(Fcntl::F_GETFL) | Fcntl::O_NONBLOCK)
+        raise ModBus::Errors::ModBusTimeout, 'Device does not respond' unless read_ready?(READ_TIMEOUT)
+        sleep(THREAD_SLEEP)
+       
+        #read up to and including the @uid
+        #(uid is not returned as part of the message by the read_pdu message
+        header = ''    
+        begin
+          #check again that there is data to read
+          while header.bytesize < 7 && read_ready?(READ_TIMEOUT)
+            header+=@io.sysread(7-header.bytesize)
+         end
+                 
+        rescue SystemCallError, Errno::EAGAIN, EOFError => er
+          $log.debug 'Rx :'+logging_bytes(header)
+          $log.debug 'Rx : read error ' + er.to_s
+          #next line will catch
         end
+        raise ModBus::Errors::ProtocolError, "Incomplete ModbusTCP header read" unless header && header.bytesize==7
+        
+        tin = header[0,2].unpack('n')[0]
+          
+        raise Errors::ModBusException.new("Transaction number mismatch") unless tin == @transaction
+        #data length includes the uid, so remove it as we read it in the header
+        len = header[4,2].unpack('n')[0]-1
+        msg=''    
+        begin
+          #check again that there is data to read
+          while msg.bytesize < len && read_ready?(READ_TIMEOUT)
+            msg+=@io.sysread(len-msg.bytesize)
+          end
+                 
+        rescue SystemCallError, Errno::EAGAIN, EOFError => er
+          $log.debug 'Rx :'+logging_bytes(msg)
+          $log.debug 'Rx : read error ' + er.to_s
+          #next line will catch
+        end
+        raise ModBus::Errors::ProtocolError, "Incomplete ModbusTCP message read" unless msg && msg.bytesize==len
+        
+        log "Rx (#{(header + msg).bytesize} bytes): " + logging_bytes(header + msg)
+        msg
+      rescue Exception, ModBus::Errors::ModBusException =>er
+        log er.inspect #+er.backtrace[0..2].join(',')
+        raise er if er.kind_of? ModBus::Errors::ModBusTimeout
+      ensure
+        msg ||=''
+        #log "Rx Message : " + logging_bytes(msg)
+        msg
       end
     end
+    
   end
 end

--- a/spec/read_rtu_response_spec.rb
+++ b/spec/read_rtu_response_spec.rb
@@ -2,30 +2,44 @@
 require 'rmodbus'
 
 #Use public wrap method
-class ModBus::Client
+class ModBus::Slave
   include ModBus::RTU
   def test_read_method(msg)
     io = TestIO.new(msg)
     read_rtu_response(io)
   end
+  
+  def read_ready?(timeout)
+    true
+  end
+  alias :write_ready? :read_ready?
+
 
 end
 
 class TestIO
+  attr_accessor :read_timeout
+  
   def initialize(msg)
     @msg = msg
+    @read_timeout=100
   end
 
-  def read(num)
+  def sysread(num)
     result = @msg[0,num]
     @msg = @msg[num..-1]
     result
   end
+  
+  def t_3_5
+    0.01
+  end
+    
 end
 
 describe "#read_rtu_response" do
   before do
-    @cl_mb = ModBus::Client.new   
+    @cl_mb = ModBus::Slave.new(1,nil)  
   end
 
   it "should read response for 'read coils'" do

--- a/spec/tcp_client_spec.rb
+++ b/spec/tcp_client_spec.rb
@@ -9,34 +9,50 @@ describe ModBus::TCPClient do
       @adu = "\000\001\000\000\000\001\001"
   
       TCPSocket.should_receive(:new).with('127.0.0.1', 1502).and_return(@sock)
-      @sock.stub!(:read).with(0).and_return('')
+      @sock.stub!(:sysread).with(0).and_return('')
+      @sock.stub!(:syswrite){|msg| msg.size}
+      @sock.should_receive(:flush).any_number_of_times
+      @sock.should_receive(:fcntl).any_number_of_times
+          
       @cl = ModBus::TCPClient.new('127.0.0.1', 1502)
       @slave = @cl.with_slave(@uid)
+      @slave.stub!(:read_ready?){|array| array }
+      @slave.stub!(:write_ready?){|array| array }
     end
     
-    it 'should send valid MBAP Header' do
+    it 'should send a valid MBAP Header' do
       @adu[0,2] = @slave.transaction.next.to_word
-      @sock.should_receive(:write).with(@adu)
-      @sock.should_receive(:read).with(7).and_return(@adu)
-      @slave.query('').should == nil
+      @sock.should_receive(:syswrite).with(@adu)
+      @sock.should_receive(:sysread).any_number_of_times.with(7).and_return(@adu)
+      
+      #empty query causes an empty reply in the mock object
+      #Slave#query catches it and throws a timeout, because we have
+      #timed out after the header and before the data
+      expect{ @slave.query('') }.to raise_error(ModBus::Errors::ModBusTimeout, "Response Failure")
     end
     
-    it 'should not throw exception and white next packet if get other transaction' do
-      @adu[0,2] = @slave.transaction.next.to_word
-      @sock.should_receive(:write).with(@adu)
-      @sock.should_receive(:read).with(7).and_return("\000\002\000\000\000\001" + @uid.chr)
-      @sock.should_receive(:read).with(7).and_return("\000\001\000\000\000\001" + @uid.chr)
-
-      expect{ @slave.query('') }.to_not raise_error
-    end
+# this test removed because we now throw an exception if we have a mismatch
+# because we have a query lock to stop two queries trying to happen simultaneously 
+#    it 'should not throw exception and write next packet if get other transaction' do
+#      @adu[0,2] = @slave.transaction.next.to_word
+#      @sock.should_receive(:write).with(@adu)
+#      @sock.should_receive(:read).with(7).and_return("\000\002\000\000\000\001" + @uid.chr)
+#      @sock.should_receive(:read).with(7).and_return("\000\001\000\000\000\001" + @uid.chr)
+#
+#      expect{ @slave.query('') }.to_not raise_error
+#    end
     
-    it 'should throw timeout exception if do not get own transaction' do
+    
+    #we now have Thread-safe transactional processing, so a wrong transaction number is pretty serious!
+    #it is not just a case of ignoring it and moving on.
+    it 'should throw ModBusTimeout exception if it does not get own transaction' do
       @slave.read_retries = 2
       @adu[0,2] = @slave.transaction.next.to_word
       @sock.should_receive(:write).any_number_of_times.with(/\.*/)
       @sock.should_receive(:read).any_number_of_times.with(7).and_return("\000\x3\000\000\000\001" + @uid.chr)
-
-      expect{ @slave.query('') }.to raise_error(ModBus::Errors::ModBusTimeout, "Timed out during read attempt")
+      @sock.should_receive(:flush).any_number_of_times
+      
+      expect{ @slave.query('') }.to raise_error(ModBus::Errors::ModBusTimeout, "Response Failure")
     end
 
     
@@ -44,9 +60,11 @@ describe ModBus::TCPClient do
       request = "\x3\x0\x6b\x0\x3"
       response = "\x3\x6\x2\x2b\x0\x0\x0\x64"
       @adu = @slave.transaction.next.to_word + "\x0\x0\x0\x9" + @uid.chr + request
-      @sock.should_receive(:write).with(@adu[0,4] + "\0\6" + @uid.chr + request)
-      @sock.should_receive(:read).with(7).and_return(@adu[0,7])
-      @sock.should_receive(:read).with(8).and_return(response)
+      @sock.should_receive(:syswrite).with(@adu[0,4] + "\0\6" + @uid.chr + request)
+      @sock.should_receive(:sysread).with(7).and_return(@adu[0,7])
+      @sock.should_receive(:sysread).with(8).and_return(response)
+      @sock.should_receive(:flush).any_number_of_times
+      
   
       @slave.query(request).should == response[2..-1]
     end


### PR DESCRIPTION
This is the first of a set of patches to the rmodbus library, based on several years of field experience with rmodbus on embedded ruby platforms. 

This commit pulls in 2 main features on the client side (they are intertwined in the way the code is written, which is why they are in a single commit, not in 2 separate commits).
- Thread safety: queries (request / response) lock the interface for the
  smallest time possible while the query executes.
- Closer adherence to the modbus specifications in PDU send and receive.
  This is necessary as noisy RS485 interfaces can fail at any point. The
  revised code is much more resilient to a whole series of failure modes.
  Additionally, the code is based on ruby 1.8.7 (as some embedded
  platforms I have been working on do not support ruby 1.9 onwards, as
  they have not got a working pthreads implementation).

As a result, a small number of tests have been removed as they are no
longer relevant, and other tests have been revised as the serial port
read / write sequences are slightly changes (some single bytes instead
of multiple bytes)

There are further commits to follow:
- server side improvements
- there is currently some ambiguity as I have been using a Logger based
  logging in addition to the $stderr based log that the rmodbus library
  uses. I plan to upgrade this, but it requires some more rewriting of the
  test sequences
