### PR TITLE
serialport -> rubyserial, Travis CI Ruby version updates, Bundler restriction lift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.6.5
   - 2.5.7
   - 2.4.9
-  - jruby-9.1.2.0
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
 script: "bundle exec rake spec"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.4.1
-  - 2.3.1
-  - 2.2.5
+  - 2.6.5
+  - 2.5.7
+  - 2.4.9
   - jruby-9.1.2.0
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.6.5
   - 2.5.7
   - 2.4.9
+  - jruby-head
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
 script: "bundle exec rake spec"

--- a/NEWS.md
+++ b/NEWS.md
@@ -162,7 +162,4 @@ The built-in examples assume registers in a particular order but it's trivial to
 
 Support JRuby
 --------------------------------------
-Now you could use RModBus on JRuby without RTU implementation.
-
-RTU classes requires gem [serialport](https://github.com/hparra/ruby-serialport) which
-currently not compatible with JRuby
+By switching from [serialport](https://github.com/hparra/ruby-serialport) to [rubyserial](https://github.com/hybridgroup/rubyserial), JRuby _should_ be supported.  The `serialport` gem had configurability for flow control, whereas the `rubyserial` gem does not seem to have that configuration exposed.  So be sure to test for your use case.

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Or if you are using bundler, add to your Gemfile:
 gem 'rmodbus'
 ```
 
-If you want to use ModBus over serial, you will also need to install the 'serialport' gem.
+If you want to use ModBus over serial, you will also need to install the 'rubyserial' gem.
 If you are using bundler, add to your Gemfile:
 
 ```
-gem 'serialport'
+gem 'rubyserial'
 ```
 
 If you want to use ModBus::TCPServer or ModBus::RTUViaTCPServer and are using Ruby >= 2.2,

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
   begin
-    require 'serialport'
+    require 'rubyserial'
   rescue LoadError => e
     spec.pattern.exclude("spec/rtu_client_spec.rb", "spec/rtu_server_spec.rb")
   end

--- a/lib/rmodbus/sp.rb
+++ b/lib/rmodbus/sp.rb
@@ -1,7 +1,7 @@
 begin
-  require 'serialport'
+  require 'rubyserial'
 rescue Exception => e
-  warn "[WARNING] Install `serialport` gem for use RTU protocols"
+  warn "[WARNING] Install `rubyserial` gem for use RTU protocols"
 end
 
 module ModBus
@@ -16,19 +16,18 @@ module ModBus
     # @option opts [Integer] :stop_bits 1 or 2
     # @option opts [Integer] :parity NONE, EVEN or ODD
     # @option opts [Integer] :read_timeout default 100 ms
-    # @return [SerialPort] io serial port
+    # @return [Serial] io serial port
     def open_serial_port(port, baud, opts = {})
       @port, @baud = port, baud
 
-      @data_bits, @stop_bits, @parity, @read_timeout = 8, 1, SerialPort::NONE, 100
+      @data_bits, @stop_bits, @parity, @read_timeout = 8, 1, :none, 100
 
       @data_bits = opts[:data_bits] unless opts[:data_bits].nil?
       @stop_bits = opts[:stop_bits] unless opts[:stop_bits].nil?
       @parity = opts[:parity] unless opts[:parity].nil?
       @read_timeout = opts[:read_timeout] unless opts[:read_timeout].nil?
 
-      io = SerialPort.new(@port, @baud, @data_bits, @stop_bits, @parity)
-      io.flow_control = SerialPort::NONE
+      io = Serial.new(@port, @baud, @data_bits, @stop_bits, @parity)
       io.read_timeout = @read_timeout
       io
     end

--- a/rmodbus.gemspec
+++ b/rmodbus.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = ["README.md", "NEWS.md"]
 
   gem.add_development_dependency 'rake','~>10.4'
-  gem.add_development_dependency 'bundler', '~>1.7'
+  gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'rspec', '~>2.99'
   gem.add_development_dependency 'guard-rspec', '~>1.2'
   gem.add_development_dependency 'pry', '~>0.10'

--- a/rmodbus.gemspec
+++ b/rmodbus.gemspec
@@ -15,11 +15,11 @@ Gem::Specification.new do |gem|
   gem.rdoc_options = ["--title", "RModBus", "--inline-source", "--main", "README.md"]
   gem.extra_rdoc_files = ["README.md", "NEWS.md"]
 
-  gem.add_development_dependency 'rake','~>10.4'
+  gem.add_development_dependency 'rake','~> 10.4'
   gem.add_development_dependency 'bundler'
-  gem.add_development_dependency 'rspec', '~>2.99'
-  gem.add_development_dependency 'guard-rspec', '~>1.2'
-  gem.add_development_dependency 'pry', '~>0.10'
+  gem.add_development_dependency 'rspec', '~> 2.99'
+  gem.add_development_dependency 'guard-rspec', '~> 1.2'
+  gem.add_development_dependency 'pry', '~> 0.10'
   gem.add_development_dependency 'serialport', '~> 1.3'
   gem.add_development_dependency 'gserver', '~> 0.0'
 end

--- a/rmodbus.gemspec
+++ b/rmodbus.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 2.99'
   gem.add_development_dependency 'guard-rspec', '~> 1.2'
   gem.add_development_dependency 'pry', '~> 0.10'
-  gem.add_development_dependency 'serialport', '~> 1.3'
+  gem.add_development_dependency 'rubyserial', '~> 0.6'
   gem.add_development_dependency 'gserver', '~> 0.0'
 end

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -52,20 +52,19 @@ describe ModBus::TCPClient  do
 end
 
 begin
-  require "serialport"
+  require "rubyserial"
   describe ModBus::RTUClient do
     before do 
       @sp = double('Serial port')
 
-      SerialPort.should_receive(:new).with("/dev/port1", 9600, 7, 2, SerialPort::ODD).and_return(@sp)
-      SerialPort.stub(:public_method_defined?).with(:flush_input).and_return(true)
+      Serial.should_receive(:new).with("/dev/port1", 9600, 7, 2, :odd).and_return(@sp)
+      Serial.stub(:public_method_defined?).with(:flush_input).and_return(true)
 
-      @sp.stub(:class).and_return(SerialPort)
-      @sp.should_receive(:flow_control=).with(SerialPort::NONE)
+      @sp.stub(:class).and_return(Serial)
       @sp.stub(:read_timeout=)
       @sp.stub(:flush_input)
 
-      @slave = ModBus::RTUClient.new("/dev/port1", 9600, :data_bits => 7, :stop_bits => 2, :parity => SerialPort::ODD).with_slave(1)
+      @slave = ModBus::RTUClient.new("/dev/port1", 9600, data_bits: 7, stop_bits: 2, parity: :odd).with_slave(1)
       @slave.read_retries = 0
 
     end

--- a/spec/rtu_client_spec.rb
+++ b/spec/rtu_client_spec.rb
@@ -5,15 +5,14 @@ describe ModBus::RTUClient do
   before do 
     @sp = double('Serial port')
 
-    SerialPort.should_receive(:new).with("/dev/port1", 9600, 8, 1, 0).and_return(@sp)    
-    SerialPort.stub(:public_method_defined?).with(:flush_input).and_return(true)
+    Serial.should_receive(:new).with("/dev/port1", 9600, 8, 1, :none).and_return(@sp)    
+    Serial.stub(:public_method_defined?).with(:flush_input).and_return(true)
 
     @sp.stub(:read_timeout=)
-    @sp.stub(:class).and_return(SerialPort)
-    @sp.should_receive(:flow_control=).with(SerialPort::NONE)
+    @sp.stub(:class).and_return(Serial)
     @sp.stub(:flush_input)
 
-    @cl = ModBus::RTUClient.new("/dev/port1", 9600, :data_bits => 8, :stop_bits => 1, :parity => SerialPort::NONE)
+    @cl = ModBus::RTUClient.new("/dev/port1", 9600, data_bits: 8, stop_bits: 1, parity: :none)
     @slave = @cl.with_slave(1)
     @slave.read_retries = 1
   end
@@ -41,16 +40,15 @@ describe ModBus::RTUClient do
 
   it 'should sugar connect method' do
     port, baud = "/dev/port1", 4800
-    SerialPort.should_receive(:new).with(port, baud, 8, 1, SerialPort::NONE).and_return(@sp)    
+    Serial.should_receive(:new).with(port, baud, 8, 1, :none).and_return(@sp)    
     @sp.should_receive(:closed?).and_return(false)
     @sp.should_receive(:close)
-    @sp.should_receive(:flow_control=).with(SerialPort::NONE)
     ModBus::RTUClient.connect(port, baud) do |cl|
       cl.port.should == port
       cl.baud.should == baud
       cl.data_bits.should == 8
       cl.stop_bits.should == 1
-      cl.parity.should == SerialPort::NONE
+      cl.parity.should == :none
     end
   end
 

--- a/spec/rtu_server_spec.rb
+++ b/spec/rtu_server_spec.rb
@@ -3,10 +3,9 @@ require 'rmodbus'
 
 describe ModBus::RTUServer do
   before do
-    @sp = double('SerialPort')
-    SerialPort.should_receive(:new).with('/dev/ttyS0', 4800, 7, 2, SerialPort::NONE).and_return(@sp)
+    @sp = double('Serial')
+    Serial.should_receive(:new).with('/dev/ttyS0', 4800, 7, 2, :none).and_return(@sp)
     @sp.stub(:read_timeout=)
-    @sp.should_receive(:flow_control=).with(SerialPort::NONE)
 
     @server = ModBus::RTUServer.new('/dev/ttyS0', 4800, 1, :data_bits => 7, :stop_bits => 2)
     @server.coils = [1,0,1,1]
@@ -25,6 +24,6 @@ describe ModBus::RTUServer do
     @server.baud.should == 4800
     @server.data_bits.should == 7
     @server.stop_bits.should == 2
-    @server.parity.should == SerialPort::NONE
+    @server.parity.should == :none
   end
 end


### PR DESCRIPTION
- Switch from the serialport gem to the rubyserial gem - #46 
- Update the versions of MRI Ruby that get tested in Travis to the latest supported versions
- Remove jruby from Travis, as it fails to build the serialport gem
- Remove the overly-strict restriction on the version of Bundler to help folks with more recent installs have an easier time contributing
- Whitespace-only: Make the gem dependency formatting consistent